### PR TITLE
Bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 [Unreleased]
 
+[2.2.2] - 2025-07-18
+
+### Changes
+
+- Fix HTTPoison client to handle non-200 status codes
+
 [2.2.1] - 2024-12-17
 
 ### Changes

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Geocoder.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/CyrusOfEden/geocoder"
-  @version "2.2.1"
+  @version "2.2.2"
 
   def project do
     [


### PR DESCRIPTION
Updates version in mix.exs and adds changelog entry for HTTPoison client fix.