### PR TITLE
chore: raise minimum Elixir to 1.17 and Erlang/OTP to 27, fix red CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,29 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://repo.hex.pm/builds/elixir/builds.txt
-        elixir: [1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
-        otp: [24.x, 25.x, 26.x, 27.x, 28.x]
-        exclude:
-          # Elixir 1.19 requires OTP 26+
-          - elixir: 1.19
-            otp: 24.x
-          - elixir: 1.19
-            otp: 25.x
-          # Elixir 1.18 requires OTP 25+
-          - elixir: 1.18
-            otp: 24.x
-          # Elixir 1.17 requires OTP 25+
-          - elixir: 1.17
-            otp: 24.x
-          # Elixir 1.16 requires OTP 24+
-          - elixir: 1.14
-            otp: 28.x
-          - elixir: 1.15
-            otp: 28.x
+        # Only pairs that actually exist. Elixir/OTP compatibility:
+        # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
+        #   1.17 -> OTP 25-27   1.19 -> OTP 26-28
+        #   1.18 -> OTP 25-27   1.20 -> OTP 27-29
+        # Floors are Elixir 1.17 / OTP 27 (see mix.exs); OTP 26 and below are EOL.
         include:
-          - elixir: 1.16
-            otp: 26.x
+          - elixir: "1.17"
+            otp: "27.x"
+          - elixir: "1.18"
+            otp: "27.x"
+          - elixir: "1.19"
+            otp: "27.x"
+          - elixir: "1.19"
+            otp: "28.x"
+          - elixir: "1.20"
+            otp: "27.x"
+          - elixir: "1.20"
+            otp: "28.x"
+          - elixir: "1.20"
+            otp: "29.x"
             lint: lint
             coverage: coverage
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26.x
-          elixir-version: 1.15
+          otp-version: "27.x"
+          elixir-version: "1.17"
       - name: Publish package to hex.pm
         uses: cucumber/action-publish-hex@v1.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 [Unreleased]
 
+### Changes
+
+- Change minimum Elixir version to 1.17 and minimum Erlang/OTP version to 27.
+  Elixir 1.16 and below top out at OTP 26, and OTP 26 and below are end-of-life.
+- Prune the CI matrix to Elixir/OTP pairs that actually exist
+
 [2.2.2] - 2025-07-18
 
 ### Changes

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Geocoder.Mixfile do
     [
       app: :geocoder,
       version: @version,
-      elixir: "~> 1.14",
-      otp: "~> 24",
+      elixir: "~> 1.17",
+      otp: "~> 27",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/geocoder/providers/google_maps_test.exs
+++ b/test/geocoder/providers/google_maps_test.exs
@@ -77,7 +77,7 @@ defmodule Geocoder.Providers.GoogleMapsTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end
@@ -145,7 +145,7 @@ defmodule Geocoder.Providers.GoogleMapsTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end

--- a/test/geocoder/providers/open_cage_data_test.exs
+++ b/test/geocoder/providers/open_cage_data_test.exs
@@ -75,7 +75,7 @@ defmodule Geocoder.Providers.OpenCageDataTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end
@@ -143,7 +143,7 @@ defmodule Geocoder.Providers.OpenCageDataTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end

--- a/test/geocoder/providers/open_street_maps_test.exs
+++ b/test/geocoder/providers/open_street_maps_test.exs
@@ -81,7 +81,7 @@ defmodule Geocoder.Providers.OpenStreetMapsTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end
@@ -161,7 +161,7 @@ defmodule Geocoder.Providers.OpenStreetMapsTest do
         )
 
       assert is_list(coords)
-      assert Enum.count(coords) > 0
+      refute Enum.empty?(coords)
       assert_belgium(coords |> List.first())
     end
   end

--- a/test/geocoder_test.exs
+++ b/test/geocoder_test.exs
@@ -47,13 +47,13 @@ defmodule GeocoderTest do
   test "A list of results for an address in Belgium" do
     {:ok, coords} = Geocoder.call_list("Dikkelindestraat 46, 9032 Wondelgem, Belgium")
     assert is_list(coords)
-    assert Enum.count(coords) > 0
+    refute Enum.empty?(coords)
     assert_belgium(coords |> List.first())
   end
 
   test "A list of results for coordinates" do
     {:ok, coords} = Geocoder.call_list({51.0775264, 3.7073382})
     assert is_list(coords)
-    assert Enum.count(coords) > 0
+    refute Enum.empty?(coords)
   end
 end


### PR DESCRIPTION
## Summary

CI on this repo is currently red on every matrix job. This fixes both causes and
brings the supported version floors up to versions that are still maintained.

- Raise the floors to Elixir 1.17 / Erlang OTP 27 in `mix.exs`
- Rebuild the CI matrix so it only contains Elixir/OTP pairs that actually exist
- Fix the eight `credo --strict` warnings that were failing CI on every row

## Why CI is red today

Two independent causes, both of which affect every job:

1. **The matrix generates combinations that do not exist.** The `elixir × otp`
   product plus a partial `exclude` list produces pairs like `1.14 × 27.x`,
   `1.16 × 28.x` and `1.15 × 27.x`. Each of those dies at `setup-beam`.
2. **`mix credo --strict` exits 16 on every valid row**, from eight
   `assert Enum.count(coords) > 0` calls in the test suite.

## Why the floors move, and why they move together

Elixir 1.14 and 1.15 are off the
[support table](https://hexdocs.pm/elixir/compatibility-and-deprecations.html)
entirely — they no longer receive even security patches. OTP maintains only its
last three majors (27, 28, 29), so OTP 26 and below are end-of-life.

The two floors are coupled: Elixir 1.16 supports OTP 24–26 only, so it cannot be
the floor alongside OTP 27. The lowest Elixir that runs OTP 27 is **1.17**.

This is a support-matrix change for downstream users, so it is worth a minor
version bump when released. Users on Elixir < 1.17 can stay on `2.2.x`.

The resulting matrix is an include-only list of the seven real pairs:

| Elixir | OTP |
|--------|-----|
| 1.17 | 27 |
| 1.18 | 27 |
| 1.19 | 27, 28 |
| 1.20 | 27, 28, 29 (lint + coverage) |

Version values are quoted, because YAML parses an unquoted `1.20` as the float
`1.2` and would hand `setup-beam` a bogus version.

## Changes

- `mix.exs` — `elixir: "~> 1.17"`, `otp: "~> 27"`
- `.github/workflows/elixir.yml` — include-only matrix; lint/coverage moved to the newest supported pair
- `.github/workflows/publish.yml` — was pinned to Elixir 1.15 / OTP 26, both now below the floor; moved to the floor pair
- `test/**` — `assert Enum.count(coords) > 0` → `refute Enum.empty?(coords)` (kept as its own commit)
- `CHANGELOG.md` — entry under `[Unreleased]`

No library code changes; `lib/` is untouched.

## Test Plan

- [x] All seven matrix jobs green on the fork: https://github.com/epinault/geocoder/pull/3
- [x] `mix format --check-formatted`, `mix deps.unlock --check-unused`, `mix compile --warnings-as-errors` → all 0
- [x] `mix test` → 39 passed
- [x] `mix credo --strict` → 0 (was 16)

## Follow-up

This unblocks, but does not include, `httpoison 2.x → 3.0` / `hackney 4`, which
fixes ten CVEs in hackney 1.25 and requires exactly these floors (hackney 4 needs
OTP 27, httpoison 3.0 needs Elixir 1.17). Happy to send that separately.

---
🤖 Generated with Claude Code by Emmanuel Pinault

https://claude.ai/code/session_01XsKnkn4gGKUEkHxmv5pNoT