### PR TITLE
build(deps): allow httpoison 3.x alongside 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Change minimum Elixir version to 1.17 and minimum Erlang/OTP version to 27.
   Elixir 1.16 and below top out at OTP 26, and OTP 26 and below are end-of-life.
 - Prune the CI matrix to Elixir/OTP pairs that actually exist
+- Allow `httpoison` 3.x in addition to 2.x, so downstream apps can opt into
+  hackney 4 (which fixes several CVEs in hackney 1.x) without being forced onto it
 
 [2.2.2] - 2025-07-18
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Geocoder.Mixfile do
   defp deps do
     [
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:httpoison, "~> 2.1", optional: true},
+      {:httpoison, "~> 2.1 or ~> 3.0", optional: true},
       {:jason, "~> 1.2", optional: true},
       {:jsx, "~> 2.8 or ~> 3.0", optional: true},
       {:towel, "~> 0.2.2"},


### PR DESCRIPTION
## Summary

One-line constraint change: `{:httpoison, "~> 2.1 or ~> 3.0", optional: true}`.

httpoison 3.0 moves to hackney 4, which fixes ten CVEs present in hackney 1.x.
It also swaps hackney's HTTP/2 and HTTP/3 stacks for the newer `h2`, `quic` and
`webtransport` libraries, and changes some runtime behavior (HTTP/2 by default
over TLS, a redesigned connection pool, the built-in metrics subsystem removed).

Since `httpoison` is an **optional** dependency, downstream apps are better
placed than this library to weigh that tradeoff. This permits both majors rather
than picking one for them: apps that want the CVE fixes can take 3.0, apps that
would rather not pull in the newer QUIC stack can stay on 2.x.

`mix.lock` is deliberately left at httpoison 2.3.0. This changes what is
*allowed*, not what anyone gets by default.

## No client code changes needed

The calls this library actually makes are stable across both majors:

- `:hackney.request/5` and `:hackney_url.qs/1` keep their names and shapes
- `:with_body` yields the same `{:ok, status, headers, body}` whether it is
  honored (hackney 1.x) or ignored (hackney 4 always returns the body)
- `HTTPoison.request/5` still returns `%HTTPoison.Response{}`

## Test Plan

Resolved and ran the suite both ways from this identical `mix.exs`:

| Trial | Resolves to | Compile | Tests |
|---|---|---|---|
| Lock untouched | httpoison 2.3.0 + hackney 1.25.0 | 0 | 39 passed |
| `mix deps.update httpoison` | httpoison 3.0.0 + hackney 4.7.4 | 0 | 39 passed |

- [x] All seven CI jobs green on the fork: https://github.com/epinault/geocoder/pull/4
- [x] `mix format --check-formatted`, `mix deps.unlock --check-unused`, `mix compile --warnings-as-errors` → all 0
- [x] `mix credo --strict` → 0

## Unrelated issue noticed while testing

`Geocoder.Store` builds its cache key at `lib/geocoder/store.ex:58` by joining
the values of a map:

```elixir
|> Map.take(~w[city state country]a)
|> Enum.filter(&is_binary(elem(&1, 1)))
|> Enum.map_join("", &elem(&1, 1))
```

`Map.take/2` returns a map, so `map_join` iterates in map order, which is not
stable. The same address produces `flandersghentbelgium` on one run and
`flandersbelgiumghent` on another, meaning one location can end up under two
different link keys. This makes `test/geocoder/store_test.exs:28` flaky (it is
what the `System.otp_release()` conditional at line 34 is working around), and
in a long-running system it means duplicate link entries and cache misses.

Not touched here since it is unrelated to this change and altering the key format
deserves its own PR — happy to send one if you would like.

---
🤖 Generated with Claude Code by Emmanuel Pinault

https://claude.ai/code/session_01XsKnkn4gGKUEkHxmv5pNoT